### PR TITLE
Add valid drupal ID to purger and update configuration check file

### DIFF
--- a/src/Plugin/Purge/DiagnosticCheck/ConfigurationCheck.php
+++ b/src/Plugin/Purge/DiagnosticCheck/ConfigurationCheck.php
@@ -12,11 +12,11 @@ use Drupal\section_purger\Entity\SectionPurgerSettings;
  * Verifies that only fully configured HTTP purgers load.
  *
  * @PurgeDiagnosticCheck(
- *   id = "httpconfiguration",
- *   title = @Translation("HTTP"),
- *   description = @Translation("Verifies that only fully configured HTTP purgers load."),
+ *   id = "sectionconfiguration",
+ *   title = @Translation("Section"),
+ *   description = @Translation("Verifies that only fully configured Section purgers load."),
  *   dependent_queue_plugins = {},
- *   dependent_purger_plugins = {"http"}
+ *   dependent_purger_plugins = {"section_purger"}
  * )
  */
 class ConfigurationCheck extends DiagnosticCheckBase implements DiagnosticCheckInterface {
@@ -65,7 +65,7 @@ class ConfigurationCheck extends DiagnosticCheckBase implements DiagnosticCheckI
     // Load configuration objects for all enabled HTTP purgers.
     $plugins = [];
     foreach ($this->purgePurgers->getPluginsEnabled() as $id => $plugin_id) {
-      if (in_array($plugin_id, ['http', 'httpbundled'])) {
+      if (in_array($plugin_id, ['section_purger'])) {
         $plugins[$id] = SectionPurgerSettings::load($id);
       }
     }
@@ -74,7 +74,7 @@ class ConfigurationCheck extends DiagnosticCheckBase implements DiagnosticCheckI
     $labels  = $this->purgePurgers->getLabels();
     foreach ($plugins as $id => $settings) {
       $t = ['@purger' => $labels[$id]];
-      foreach (['name', 'hostname', 'account', 'application', 'username', 'password', 'environmentname', 'port', 'request_method', 'scheme'] as $f) {
+      foreach (['name', 'hostname', 'account', 'application', 'username', 'password', 'sitename', 'environmentname', 'port', 'request_method', 'scheme'] as $f) {
         if (empty($settings->$f)) {
           $this->recommendation = $this->t("@purger not configured.", $t);
           return SELF::SEVERITY_ERROR;

--- a/src/Plugin/Purge/DiagnosticCheck/ConfigurationCheck.php
+++ b/src/Plugin/Purge/DiagnosticCheck/ConfigurationCheck.php
@@ -16,7 +16,7 @@ use Drupal\section_purger\Entity\SectionPurgerSettings;
  *   title = @Translation("Section"),
  *   description = @Translation("Verifies that only fully configured Section purgers load."),
  *   dependent_queue_plugins = {},
- *   dependent_purger_plugins = {"section_purger"}
+ *   dependent_purger_plugins = {"section"}
  * )
  */
 class ConfigurationCheck extends DiagnosticCheckBase implements DiagnosticCheckInterface {
@@ -65,7 +65,7 @@ class ConfigurationCheck extends DiagnosticCheckBase implements DiagnosticCheckI
     // Load configuration objects for all enabled HTTP purgers.
     $plugins = [];
     foreach ($this->purgePurgers->getPluginsEnabled() as $id => $plugin_id) {
-      if (in_array($plugin_id, ['section_purger'])) {
+      if (in_array($plugin_id, ['section'])) {
         $plugins[$id] = SectionPurgerSettings::load($id);
       }
     }

--- a/src/Plugin/Purge/DiagnosticCheck/ConfigurationCheck.php
+++ b/src/Plugin/Purge/DiagnosticCheck/ConfigurationCheck.php
@@ -74,7 +74,7 @@ class ConfigurationCheck extends DiagnosticCheckBase implements DiagnosticCheckI
     $labels  = $this->purgePurgers->getLabels();
     foreach ($plugins as $id => $settings) {
       $t = ['@purger' => $labels[$id]];
-      foreach (['name', 'hostname', 'account', 'application', 'username', 'password', 'sitename', 'environmentname', 'port', 'request_method', 'scheme'] as $f) {
+      foreach (['name', 'hostname', 'account', 'application', 'username', 'password', 'environmentname', 'port', 'request_method', 'scheme'] as $f) {
         if (empty($settings->$f)) {
           $this->recommendation = $this->t("@purger not configured.", $t);
           return SELF::SEVERITY_ERROR;

--- a/src/Plugin/Purge/Purger/SectionPurger.php
+++ b/src/Plugin/Purge/Purger/SectionPurger.php
@@ -10,7 +10,7 @@ use Drupal\section_purger\Plugin\Purge\Purger\SectionPurgerBase;
  * Section Purger.
  *
  * @PurgePurger(
- *   id = "section_purger",
+ *   id = "section",
  *   label = @Translation("Section Purger"),
  *   configform = "\Drupal\section_purger\Form\SectionPurgerForm",
  *   cooldown_time = 0.0,

--- a/src/Plugin/Purge/Purger/SectionPurger.php
+++ b/src/Plugin/Purge/Purger/SectionPurger.php
@@ -10,7 +10,7 @@ use Drupal\section_purger\Plugin\Purge\Purger\SectionPurgerBase;
  * Section Purger.
  *
  * @PurgePurger(
- *   id = "Section Purger",
+ *   id = "section_purger",
  *   label = @Translation("Section Purger"),
  *   configform = "\Drupal\section_purger\Form\SectionPurgerForm",
  *   cooldown_time = 0.0,


### PR DESCRIPTION
Give section purger a valid ID and set up configuration check to test against the Section purger instead of the no longer extant http purger. Resolves #7 . Also removes an optional configuration check field (site name) from the list of required fields. 

The id 'section' has been selected to adhere to the pattern of the generic purger and the varnish purger, both of which use 'http' and 'varnish' respectively as the ids for their non-bundled purgers. 